### PR TITLE
Fix root password extraction bug in `db-container-backup.sh` script

### DIFF
--- a/db-container-backup/db-container-backup.sh
+++ b/db-container-backup/db-container-backup.sh
@@ -21,8 +21,8 @@ if [ ! -d $BACKUPDIR ]; then
 fi
 
 for i in $CONTAINER; do
-    MYSQL_DATABASE=$(docker exec $i env | grep MYSQL_DATABASE |cut -d"=" -f2)
-    MYSQL_PWD=$(docker exec $i env | grep MYSQL_ROOT_PASSWORD |cut -d"=" -f2)
+    MYSQL_DATABASE=$(docker exec $i env | grep MYSQL_DATABASE |cut -d"=" -f2-)
+    MYSQL_PWD=$(docker exec $i env | grep MYSQL_ROOT_PASSWORD |cut -d"=" -f2-)
 
     docker exec -e MYSQL_DATABASE=$MYSQL_DATABASE -e MYSQL_PWD=$MYSQL_PWD \
         $i /usr/bin/mysqldump -u root $MYSQL_DATABASE \


### PR DESCRIPTION
Resolves #1 

# Description

- This pull request fixes a bug in the `db-container-backup.sh` script where the root password extraction is incomplete if the password contains multiple equal signs (=). The current implementation only reads characters between the first occurrence of an equal sign and the next occurrence, resulting in an incomplete password value.

- For example, consider the root password `MYSQL_ROOT_PASSWORD=pass=word=123`. With the existing implementation, only "pass" would be extracted as the password, ignoring the rest of the password after the first equal sign. This leads to incorrect password handling.

- To resolve this issue, the value of the `-f` argument in the cut command has been modified. The argument has been changed from `2` to `2-` to ensure that the cut command captures the entire password, including all equal signs.

- With this pull request, the script correctly extracts the complete root password. Using the example `MYSQL_ROOT_PASSWORD=pass=word=123`, the updated implementation now captures "pass=word=123" as the correct password value.

# Steps to test

![image](https://github.com/ChristianLempa/scripts/assets/45392201/24b8520f-338d-485e-906d-5c574749234b)